### PR TITLE
Fixing build issue by adding a missing file to the CSPROJ

### DIFF
--- a/Samples/CSharp/IntuneDataWarehouseSamples.csproj
+++ b/Samples/CSharp/IntuneDataWarehouseSamples.csproj
@@ -53,6 +53,7 @@
   <ItemGroup>
     <Compile Include="AppAuthenticationSample.cs" />
     <Compile Include="Program.cs" />
+    <Compile Include="SecureStringConversion.cs" />
     <Compile Include="UserAuthenticationSample.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The C# samples currently don't build in Visual Studio. This is because a committed file was never added to the CSPROJ. 